### PR TITLE
fix: enum types

### DIFF
--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -153,7 +153,7 @@ export const makeHelpers = ({
       field.kind === 'enum',
       `@ApiProperty({ enum: ${
         fieldType(field, useInputTypes).endsWith('[]')
-          ? `[${fieldType(field, useInputTypes).replace('[]', '')}]`
+          ? `Object.values(${fieldType(field, useInputTypes).replace('[]', '')})`
           : fieldType(field, useInputTypes)
       }${enumAsSchema ? `, enumName: '${field.type}'` : ``} })\n`,
     )}${when(

--- a/src/generator/template-helpers.ts
+++ b/src/generator/template-helpers.ts
@@ -153,7 +153,7 @@ export const makeHelpers = ({
       field.kind === 'enum',
       `@ApiProperty({ enum: ${
         fieldType(field, useInputTypes).endsWith('[]')
-          ? `Object.values(${fieldType(field, useInputTypes).replace('[]', '')})`
+          ? `${fieldType(field, useInputTypes).replace('[]', '')}, isArray: true`
           : fieldType(field, useInputTypes)
       }${enumAsSchema ? `, enumName: '${field.type}'` : ``} })\n`,
     )}${when(


### PR DESCRIPTION
The `enum` in nest swagger should actually be an array of strings or numbers. But in my previous PR #2 I made a mistake.